### PR TITLE
Remove triple-dash from rendered yaml

### DIFF
--- a/templates/agent-conf.d/mysql.yaml.erb
+++ b/templates/agent-conf.d/mysql.yaml.erb
@@ -52,4 +52,4 @@ instances:
 
 <% end -%>
 
-<%= {'logs'=>@logs}.to_yaml %>
+<%= {'logs'=>@logs}.to_yaml.lines[1..-1].join %>


### PR DESCRIPTION
Tripple-dash ("---") causes the following section of the configuration to be ignored by the Datadog agent