### PR TITLE
Convert Enumerator to Array before slicing

### DIFF
--- a/templates/agent-conf.d/mysql.yaml.erb
+++ b/templates/agent-conf.d/mysql.yaml.erb
@@ -52,4 +52,4 @@ instances:
 
 <% end -%>
 
-<%= {'logs'=>@logs}.to_yaml.lines[1..-1].join %>
+<%= (Array({'logs'=>@logs}.to_yaml.lines))[1..-1].join %>


### PR DESCRIPTION
Fixes `undefined method `[]' for #<Enumerator:0x51363864>`